### PR TITLE
kernel: Nuke --cuda-path/--hip-path

### DIFF
--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -236,7 +236,7 @@ ifneq ($(TARGET_KERNEL_CLANG_COMPILE),false)
     endif
     PATH_OVERRIDE += PATH=$(TARGET_KERNEL_CLANG_PATH)/bin:$$PATH
     ifeq ($(KERNEL_CC),)
-        KERNEL_CC := CC="env HIP_PATH=none $(CCACHE_BIN) clang --cuda-path=/dev/null"
+        KERNEL_CC := CC="$(CCACHE_BIN) clang"
     endif
 endif
 


### PR DESCRIPTION
Revert "kernel: Block HIP detection through HIP_PATH=none"

This reverts commit f6ac90fa6d2c96ffcb731f17a510308170f5ac03.

Revert "[RE-PICK]kernel: Force disable LLVM CUDA"

This reverts commit 9c6863a9b9ed750025dd37c8dc721cc5e96cad3c.

Change-Id: I5cb2b4624eb0ec25dbc8c1b5888708d961ae59d7